### PR TITLE
correct max vcf size finding

### DIFF
--- a/scripts/vcf2fasta.py
+++ b/scripts/vcf2fasta.py
@@ -164,7 +164,8 @@ def get_mixture(record, threshold):
     return mixture
 
 def guess_total_records(vcfs):
-    largest_vcf = [vcf for vcf in vcfs if os.path.getsize(vcf) == max([os.path.getsize(vcf) for vcf in vcfs])][0]
+    max_size = max([os.path.getsize(vcf) for vcf in vcfs])
+    largest_vcf = [vcf for vcf in vcfs if os.path.getsize(vcf) == max_size][0]
     total_records = 0
     with open(largest_vcf) as fp:
         for _ in fp:


### PR DESCRIPTION
My initial code didn't work.
Simple change now ensures that the largest vcf file is picked when estimating the number of records that have to be processed